### PR TITLE
Support custom rule files

### DIFF
--- a/lib/atomicLoader.js
+++ b/lib/atomicLoader.js
@@ -63,6 +63,14 @@ const parseAndGenerateFile = function (configPath, source) {
         console.warn('[atomic loader] create css failed.')
         return;
     }
+    
+    // custom rules file
+    if (pathConfig.options && pathConfig.options.rules) {
+        var customRules = require(require.resolve(pathConfig.options.rules));
+        if (customRules) {
+            atomizer.addRules(customRules);
+        }
+    }
 
     const finalConfig = atomizer.getConfig(foundClasses, pathConfig.configs || {});
     const cssString = atomizer.getCss(finalConfig, pathConfig.options || {});


### PR DESCRIPTION
based on https://github.com/acss-io/atomizer#cli

we should be able to pass custom rules file by options.

Currently atomizer only add rules on init
https://github.com/acss-io/atomizer/blob/master/src/atomizer.js#L29

Not sure if this is the best place to add or we should add in `parseConfig` in `atomizer`

https://github.com/acss-io/atomizer/blob/master/src/atomizer.js#L135