### PR TITLE
Documentation improved

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Webpack loader for compiling [Atomic CSS](https://acss.io).
 1. [Atomic CSS configuration](#atomic-css-configuration)
 1. [Usage with React or Vue](#usage-with-react-or-vue)
 1. [Usage with `mini-css-extract-plugin` and `webpack-html-plugin`](#usage-with-mini-css-extract-plugin-and-webpack-html-plugin)
+1. [Usage with only `html-loader`](#usage-with-only-html-loader)
 1. [Advanced](#advanced)
 
 ## Install
@@ -23,6 +24,7 @@ $ yarn add webpack-atomizer-loader -D
 ## Atomic CSS configuration
 
 You need in a JavaScript file the Atomic CSS configuration that will be feed to the loader. For example, `atomCssConfig.js` will looks something like:
+
 ```js
 // atomCssConfig.js
 
@@ -51,14 +53,13 @@ module.exports = {
 
 ## Usage with React or Vue
 
-If the CSS atoms on your project are written in the `className` prop of JSX files follow these intructions.
-
-Find `babel-loader` or `jsx-loader` on your webpack configuration and insert `webpack-atomizer-loader` before it:
+If the CSS atoms on your project are written in the `className` prop of JSX files find `babel-loader` or `jsx-loader` on the webpack configuration and insert `webpack-atomizer-loader` before it.
 
 ```js
 // webpack.config.js
 
 const path = require('path');
+const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 
 module.exports = {
     module: {
@@ -81,7 +82,7 @@ module.exports = {
                     },
                 ]
             },
-            {
+            { // Optional. Read further down
                 test: /\.css$/, // or /\.scss$/
                 use: [
                     MiniCssExtractPlugin.loader,
@@ -95,45 +96,94 @@ module.exports = {
                 ]
             }
         ]
-    }
+    },
+    plugins: [
+        new MiniCssExtractPlugin() // Optional. Read further down
+    ]
 };
 ```
 
-You need `css-loader` which will convert CSS into a JavaScript variable every time you do `import CSS from './generatedAtoms.css`. If you use some CSS preprocessor like SASS or PostCSS you'll have to also add the corresponding loader, which will have to go after the `css-loader` on the `rules` array as shown on the above example.
+`webpack-atomizer-loader` will generate a `generatedAtoms.css` file which will have to be imported into the final `public/index.htm` file. This can be done in three different ways:
 
-`webpack-atomizer-loader` will generate a `generatedAtoms.css` file which will have to be imported in some Javascript or CSS file:
+### Including the generated CSS with JavaScript
 
-```javascript
+You can import the generated CSS file as a JavaScript module import. On the project webpack entry point file, like `index.js`:
+
+```js
 // index.js
 
 import React from 'react'
 import ReactDOM from 'react-dom'
 
-import Style from './generatedAtoms.css'
+import ProjectStyles from './projectStyles.css'
+import GeneratedAtoms from './generatedAtoms.css' // Add this line
+
 import App from './app'
 
 ReactDOM.render(<App />, document.getElementById('root'))
 ```
 
-or
+`css-loader` will convert CSS into a JavaScript variable when you do `import CSS from './generatedAtoms.css`. Then [`mini-css-extract-plugin`](https://github.com/webpack-contrib/mini-css-extract-plugin) will generate the final CSS file from the JavaScript variable created by `css-loader`.
+
+If you use some CSS preprocessor like SASS or PostCSS you'll have to also add the corresponding loader, which will have to go after the `css-loader` on the `rules` array as shown on the aforementioned config example.
+
+### Including the generated CSS with a CSS `@import`
+
+Similar to the previous option but instead of including it in `index.js` it can be done to a `index.css` file:
 
 ```css
 /* index.css */
 
 @import "projectStyles.css";
-@import "generatedAtoms.css";
+@import "generatedAtoms.css"; /* Add this line */
+```
+
+### Including the generated CSS straight into the HTML template
+
+If you don't need any CSS preprocessing functionality you can remove the entire CSS loader config:
+
+```js
+// webpack.config.js
+
+{
+	test: /\.css$/, // or /\.scss$/
+	use: [
+		MiniCssExtractPlugin.loader,
+		'css-loader',
+		{
+			loader: 'postcss-loader', // or 'sass-loader'
+			options: {
+				// ...
+			}
+		},
+	]
+}
+```
+
+and just import the generated CSS file directly into the HTML file of your template:
+
+```html
+<!-- public/index.htm -->
+
+<html>
+  <head>
+    <link href="projectStyles.css" />
+    <link href="generatedAtoms.css" />
+  </head>
 ```
 
 After this you should be able to see the Atom CSS classes loaded on the browser and applied to your components.
 
 ## Usage with `mini-css-extract-plugin` and `webpack-html-plugin`
 
-If the CSS atoms are on `class` attributes on `.htm` files (or any other template system like [`hbs`](https://github.com/pcardune/handlebars-loader), `pug` or `ejs`) you must use [`mini-css-extract-plugin`](https://github.com/webpack-contrib/mini-css-extract-plugin) and optionally [`webpack-html-plugin`](https://github.com/jantimon/html-webpack-plugin):
+If the CSS atoms are on `class` attributes on `.htm` files (or any other template system like [`hbs`](https://github.com/pcardune/handlebars-loader), `pug` or `ejs`) you can use the [`mini-css-extract-plugin`](https://github.com/webpack-contrib/mini-css-extract-plugin) and [`webpack-html-plugin`](https://github.com/jantimon/html-webpack-plugin) combo:
 
-```javascript
+```js
 // webpack.config.js
 
 const path = require('path');
+const HtmlWebpackPlugin = require("html-webpack-plugin");
+const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 
 module.exports = {
     module: {
@@ -184,7 +234,62 @@ module.exports = {
 By default if no HTML loader is specified `webpack-html-plugin` will use
 a simple [`ejs` loader](https://github.com/jantimon/html-webpack-plugin/blob/master/docs/template-option.md). However as soon as `webpack-atomizer-loader` is included the default HTML loader will be disabled and we'll have to include ours. That's why on the above configuration in addition to `webpack-atomizer-loader` it's also included `html-loader`.
 
-You only need `webpack-html-plugin` if you're using this plugin to also generate the HTML. If you have your own `public/index.htm` with a `<link href="projectStyles.css" />` element remember to include the generated Atoms with another `<link href="generatedAtoms.css" />` or in a `css` file with `@import "generatedAtoms.css"`.
+## Usage with only `html-loader`
+
+If the CSS atoms are on `class` attributes on `.htm` files (or any other template system like [`hbs`](https://github.com/pcardune/handlebars-loader), `pug` or `ejs`) and you don't require any CSS preprocessing or want to keep the webpack configuration to the minimum you can just scan HTML files to find the atoms and generate the final CSS file:
+
+```js
+// webpack.config.js
+
+const path = require('path');
+
+module.exports = {
+    module: {
+        rules: [
+            {
+                test: /\.htm$/, // or /\.hbs$/
+                use: [
+                    {
+                        loader: 'html-loader', // Or the corresponding loader for the template system you're using
+                        options: {
+                            preprocessor: () => '' // THIS LINE IS IMPORTANT
+                        }
+                    },
+                    {
+                        loader: 'webpack-atomizer-loader',
+                        options: {
+                            configPath: path.resolve('./atomCssConfig.js')
+                        }
+                    }
+                ]
+            }
+        ]
+    }
+};
+```
+
+Then on your webpack JavaScript entry file:
+
+```js
+// index.js
+
+import WillFireHTMLLoader from './templateWithAtoms.htm' // Add an import for every HTML template you have
+import WillFireHTMLLoader2 from './templateWithAtoms2.htm'
+```
+
+Every `import` will make `webpack-atomizer-loader` scaning the HTML file imported and generating the corresponding atom classes that will be stored in one single `generatedAtoms.css`. The option `preprocessor: () => ''` will prevent that the HTML imported as a JavaScript variable is added to the JavaScript bundle.
+
+Then on your HTML file:
+
+```html
+<!-- public/index.htm -->
+
+<html>
+  <head>
+    <link href="projectStyles.css" />
+    <link href="generatedAtoms.css" />
+  </head>
+```
 
   ## Advanced
 

--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ module.exports = {
         ]
     },
     plugins: [
-        new HtmlWebpackPlugin({ // Only needed if you're using this plugin
+        new HtmlWebpackPlugin({
             template: 'src/originTemplate.htm',
             filename: 'dist/destinationFile.htm'
         }),

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Webpack loader for compiling [Atomic CSS](https://acss.io).
 
 1. [Install](#install)
 1. [Atomic CSS configuration](#atomic-css-configuration)
-1. [Usage with React or Vue.js](#usage-with-react-or-vue.js)
+1. [Usage with React or Vue](#usage-with-react-or-vue)
 1. [Usage with `mini-css-extract-plugin` and `webpack-html-plugin`](#usage-with-mini-css-extract-plugin-and-webpack-html-plugin)
 1. [Advanced](#advanced)
 
@@ -49,7 +49,7 @@ module.exports = {
 
  To know more about Atomic CSS configuration check https://github.com/acss-io/atomizer#api.
 
-## Usage with React or Vue.js
+## Usage with React or Vue
 
 If the CSS atoms on your project are written in the `className` prop of JSX files follow these intructions.
 

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ or
 
 After this you should be able to see the Atom CSS classes loaded on the browser and applied to your components.
 
-## Usage with [`mini-css-extract-plugin`](https://github.com/webpack-contrib/mini-css-extract-plugin) and [`webpack-html-plugin`](https://github.com/jantimon/html-webpack-plugin)
+## Usage with `mini-css-extract-plugin` and `webpack-html-plugin`
 
 If the CSS atoms are on `class` attributes on `.htm` files (or any other template system like [`hbs`](https://github.com/pcardune/handlebars-loader), `pug` or `ejs`) you must use [`mini-css-extract-plugin`](https://github.com/webpack-contrib/mini-css-extract-plugin) and optionally [`webpack-html-plugin`](https://github.com/jantimon/html-webpack-plugin):
 

--- a/README.md
+++ b/README.md
@@ -47,9 +47,9 @@ module.exports = {
 }
 ```
 
- To assign the output destination of the generated CSS the parameter `cssDest` should be set. If no specified the default value of `cssDest` is `./build/css/atomic.css`.
+To assign the output destination of the generated CSS the parameter `cssDest` should be set. If no specified the default value of `cssDest` is `./build/css/atomic.css`.
 
- To know more about Atomic CSS configuration check https://github.com/acss-io/atomizer#api.
+To know more about Atomic CSS configuration check https://github.com/acss-io/atomizer#api.
 
 ## Usage with React or Vue
 
@@ -103,7 +103,7 @@ module.exports = {
 };
 ```
 
-`webpack-atomizer-loader` will generate a `generatedAtoms.css` file which will have to be imported into the final `public/index.htm` file. This can be done in three different ways:
+`webpack-atomizer-loader` will generate a `generatedAtoms.css` file which will have to be imported into the final `public/index.html` file. This can be done in three different ways:
 
 ### Including the generated CSS with JavaScript
 
@@ -163,12 +163,12 @@ If you don't need any CSS preprocessing functionality you can remove the entire 
 and just import the generated CSS file directly into the HTML file of your template:
 
 ```html
-<!-- public/index.htm -->
+<!-- public/index.html -->
 
 <html>
   <head>
-    <link href="projectStyles.css" />
-    <link href="generatedAtoms.css" />
+    <link href="projectStyles.css" rel="stylesheet" type="text/css" />
+    <link href="generatedAtoms.css" rel="stylesheet" type="text/css" />
   </head>
 ```
 
@@ -176,7 +176,7 @@ After this you should be able to see the Atom CSS classes loaded on the browser 
 
 ## Usage with `mini-css-extract-plugin` and `webpack-html-plugin`
 
-If the CSS atoms are on `class` attributes on `.htm` files (or any other template system like [`hbs`](https://github.com/pcardune/handlebars-loader), `pug` or `ejs`) you can use the [`mini-css-extract-plugin`](https://github.com/webpack-contrib/mini-css-extract-plugin) and [`webpack-html-plugin`](https://github.com/jantimon/html-webpack-plugin) combo:
+If the CSS atoms are on `class` attributes on `.html` files (or any other template system like [`hbs`](https://github.com/pcardune/handlebars-loader), `pug` or `ejs`) you can use the [`mini-css-extract-plugin`](https://github.com/webpack-contrib/mini-css-extract-plugin) and [`webpack-html-plugin`](https://github.com/jantimon/html-webpack-plugin) combo:
 
 ```js
 // webpack.config.js
@@ -202,7 +202,7 @@ module.exports = {
                 ]
             },
             {
-                test: /\.htm$/, // or /\.hbs$/
+                test: /\.html$/, // or /\.hbs$/
                 use: [
                     {
                         loader: 'html-loader', // Or the corresponding loader for the template system you're using
@@ -236,7 +236,7 @@ a simple [`ejs` loader](https://github.com/jantimon/html-webpack-plugin/blob/mas
 
 ## Usage with only `html-loader`
 
-If the CSS atoms are on `class` attributes on `.htm` files (or any other template system like [`hbs`](https://github.com/pcardune/handlebars-loader), `pug` or `ejs`) and you don't require any CSS preprocessing or want to keep the webpack configuration to the minimum you can just scan HTML files to find the atoms and generate the final CSS file:
+If the CSS atoms are on `class` attributes on `.html` files (or any other template system like [`hbs`](https://github.com/pcardune/handlebars-loader), `pug` or `ejs`) and you don't require any CSS preprocessing or want to keep the webpack configuration to the minimum you can just scan HTML files to find the atoms and generate the final CSS file:
 
 ```js
 // webpack.config.js
@@ -247,7 +247,7 @@ module.exports = {
     module: {
         rules: [
             {
-                test: /\.htm$/, // or /\.hbs$/
+                test: /\.html$/, // or /\.hbs$/
                 use: [
                     {
                         loader: 'html-loader', // Or the corresponding loader for the template system you're using
@@ -273,8 +273,8 @@ Then on your webpack JavaScript entry file:
 ```js
 // index.js
 
-import WillFireHTMLLoader from './templateWithAtoms.htm' // Add an import for every HTML template you have
-import WillFireHTMLLoader2 from './templateWithAtoms2.htm'
+import WillFireHTMLLoader from './templateWithAtoms.html' // Add an import for every HTML template you have
+import WillFireHTMLLoader2 from './templateWithAtoms2.html'
 ```
 
 Every `import` will make `webpack-atomizer-loader` scaning the HTML file imported and generating the corresponding atom classes that will be stored in one single `generatedAtoms.css`. The option `preprocessor: () => ''` will prevent that the HTML imported as a JavaScript variable is added to the JavaScript bundle.
@@ -282,12 +282,12 @@ Every `import` will make `webpack-atomizer-loader` scaning the HTML file importe
 Then on your HTML file:
 
 ```html
-<!-- public/index.htm -->
+<!-- public/index.html -->
 
 <html>
   <head>
-    <link href="projectStyles.css" />
-    <link href="generatedAtoms.css" />
+    <link href="projectStyles.css" rel="stylesheet" type="text/css" />
+    <link href="generatedAtoms.css" rel="stylesheet" type="text/css" />
   </head>
 ```
 

--- a/README.md
+++ b/README.md
@@ -61,41 +61,41 @@ Find `babel-loader` or `jsx-loader` on your webpack configuration and insert `we
 const path = require('path');
 
 module.exports = {
-	module: {
-		rules: [
-			{
-				test: /\.jsx?$/, // or /\.vue?$/
-				exclude: /node_modules/,
-				use: [
-					{
-						loader: 'webpack-atomizer-loader',
-						options: {
-							configPath: path.resolve('./atomCssConfig.js')
-						}
-					},
-					{
-						loader: 'babel-loader',
-						options: {
-							presets: ['react', 'es2015']
-						}
-					},
-				]
-			},
-			{
-				test: /\.css$/, // or /\.scss$/
-				use: [
-					MiniCssExtractPlugin.loader,
-					'css-loader',
-					{
-						loader: 'postcss-loader', // or 'sass-loader'
-						options: {
-							// ...
-						}
-					},
-				]
-			}
-		]
-	}
+    module: {
+        rules: [
+            {
+                test: /\.jsx?$/, // or /\.vue?$/
+                exclude: /node_modules/,
+                use: [
+                    {
+                        loader: 'webpack-atomizer-loader',
+                        options: {
+                            configPath: path.resolve('./atomCssConfig.js')
+                        }
+                    },
+                    {
+                        loader: 'babel-loader',
+                        options: {
+                            presets: ['react', 'es2015']
+                        }
+                    },
+                ]
+            },
+            {
+                test: /\.css$/, // or /\.scss$/
+                use: [
+                    MiniCssExtractPlugin.loader,
+                    'css-loader',
+                    {
+                        loader: 'postcss-loader', // or 'sass-loader'
+                        options: {
+                            // ...
+                        }
+                    },
+                ]
+            }
+        ]
+    }
 };
 ```
 
@@ -136,48 +136,48 @@ If the CSS atoms are on `class` attributes on `.htm` files (or any other templat
 const path = require('path');
 
 module.exports = {
-	module: {
-		rules: [
-			{
-				test: /\.css$/, // or /\.scss$/
-				use: [
-					MiniCssExtractPlugin.loader,
-					'css-loader',
-					{
-						loader: 'postcss-loader', // or 'sass-loader'
-						options: {
-							// ...
-						}
-					},
-				]
-			},
-			{
-				test: /\.htm$/, // or /\.hbs$/
-				use: [
-					{
-						loader: 'html-loader', // Or the corresponding loader for the template system you're using
-						options: {
-							attributes: false,
-							minimize: true
-						}
-					},
-					{
-						loader: 'webpack-atomizer-loader',
-						options: {
-							configPath: path.resolve('./atomCssConfig.js')
-						}
-					}
-				]
-			}
-		]
-	},
-	plugins: [
-		new HtmlWebpackPlugin({ // Only needed if you're using this plugin
-			template: 'src/originTemplate.htm',
-			filename: 'dist/destinationFile.htm'
-		}),
-		new MiniCssExtractPlugin()
-	]
+    module: {
+        rules: [
+            {
+                test: /\.css$/, // or /\.scss$/
+                use: [
+                    MiniCssExtractPlugin.loader,
+                    'css-loader',
+                    {
+                        loader: 'postcss-loader', // or 'sass-loader'
+                        options: {
+                            // ...
+                        }
+                    },
+                ]
+            },
+            {
+                test: /\.htm$/, // or /\.hbs$/
+                use: [
+                    {
+                        loader: 'html-loader', // Or the corresponding loader for the template system you're using
+                        options: {
+                            attributes: false,
+                            minimize: true
+                        }
+                    },
+                    {
+                        loader: 'webpack-atomizer-loader',
+                        options: {
+                            configPath: path.resolve('./atomCssConfig.js')
+                        }
+                    }
+                ]
+            }
+        ]
+    },
+    plugins: [
+        new HtmlWebpackPlugin({ // Only needed if you're using this plugin
+            template: 'src/originTemplate.htm',
+            filename: 'dist/destinationFile.htm'
+        }),
+        new MiniCssExtractPlugin()
+    ]
 };
 ```
 

--- a/README.md
+++ b/README.md
@@ -223,8 +223,8 @@ module.exports = {
     },
     plugins: [
         new HtmlWebpackPlugin({
-            template: 'src/originTemplate.htm',
-            filename: 'dist/destinationFile.htm'
+            template: 'src/originTemplate.html',
+            filename: 'dist/destinationFile.html'
         }),
         new MiniCssExtractPlugin()
     ]


### PR DESCRIPTION
Hey @tom76kimo,

I recently used the loader in a webpack project with [`mini-css-extract-plugin`](https://github.com/webpack-contrib/mini-css-extract-plugin) and [`webpack-html-plugin`](https://github.com/jantimon/html-webpack-plugin) and I thought I could improve the loader documentation with the steps to use it with these other webpack plugins.

I've also updated the configuration examples to the webpack v4 API.

Have a look how [`README.md`](https://github.com/acss-io/webpack-atomizer-loader/blob/f90766c7afc607ab80658d1aa7235d2402c15ea4/README.md) looks like.

Looking forward to your feedback! 😊