### PR TITLE
Add file dependency when in watch mode

### DIFF
--- a/lib/atomicLoader.ts
+++ b/lib/atomicLoader.ts
@@ -103,13 +103,16 @@ const atomicLoader = function (source, map) {
 
     const query = getOptions(this) || {};
     const { config, configPath = [], minimize = false, postcssPlugins = [] } = query;
-    let validPostcssPlugins = DEFAULT_POSTCSS_PLUGIN_LIST;
+    const validPostcssPlugins = Array.isArray(postcssPlugins) ? postcssPlugins : DEFAULT_POSTCSS_PLUGIN_LIST;
+    const addDependency = this.addDependency;
 
-    if (Array.isArray(postcssPlugins)) {
-        validPostcssPlugins = postcssPlugins;
-    }
     let configs = [
-        ...[].concat(configPath).map((configPath) => require(require.resolve(configPath))),
+        ...[].concat(configPath).map((configPath) => {
+            if (addDependency) {
+                addDependency(configPath);
+            }
+            return require(require.resolve(configPath))
+        }),
         ...(config !== undefined ? [config] : []),
     ];
 

--- a/lib/atomicLoader.ts
+++ b/lib/atomicLoader.ts
@@ -108,10 +108,11 @@ const atomicLoader = function (source, map) {
 
     let configs = [
         ...[].concat(configPath).map((configPath) => {
+            // for watch mode
             if (addDependency) {
                 addDependency(configPath);
             }
-            return require(require.resolve(configPath))
+            return require(require.resolve(configPath));
         }),
         ...(config !== undefined ? [config] : []),
     ];


### PR DESCRIPTION
Based on https://webpack.js.org/contribute/writing-a-loader/#loader-dependencies

in watch mode, we need to specify file dependency.